### PR TITLE
Removes unnecessary serialization improving performance.

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ Storage.prototype.put = function (index, buf, cb) {
   }
   this._store('readwrite', function (err, store) {
     if (err) return cb(err)
-    backify(store.put(JSON.stringify(buf), index), wait(store, cb))
+    backify(store.put(buf, index), wait(store, cb))
   })
 }
 
@@ -92,7 +92,7 @@ Storage.prototype.get = function (index, opts, cb) {
         } else if (ev.target.result === undefined) {
           cb(null, new Buffer(0))
         } else {
-          var buf = new Buffer(JSON.parse(ev.target.result).data)
+          var buf = new Buffer(ev.target.result)
           if (!opts) return nextTick(cb, null, buf)
           var offset = opts.offset || 0
           var len = opts.length || (buf.length - offset)


### PR DESCRIPTION
Hey,

Currently idb-chunk-store uses JSON.stringify and JSON.parse to serialize inputs before storage, but as  IndexedDB uses the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm), JSON.stringify / JSON.parse aren't needed since all native types are supported.

All the best.